### PR TITLE
Enhancement for VoIP notification

### DIFF
--- a/config/mattermost-push-proxy.sample.json
+++ b/config/mattermost-push-proxy.sample.json
@@ -26,6 +26,16 @@
             "AppleAuthKeyFile": "",
             "AppleAuthKeyID": "",
             "AppleTeamID": ""
+        },
+        {
+            "Type":"apple_voip",
+            "ApplePushUseDevelopment":false,
+            "ApplePushCertPrivate":"",
+            "ApplePushCertPassword":"",
+            "ApplePushTopic":"com.mattermost.react.native.voip",
+            "AppleAuthKeyFile": "",
+            "AppleAuthKeyID": "",
+            "AppleTeamID": ""
         }
     ],
     "AndroidPushSettings": [

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -130,7 +130,7 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	notification.Payload = data
 	notification.Topic = me.ApplePushSettings.ApplePushTopic
 	notification.Priority = apns.PriorityHigh
-	if msg.SubType == "call" {
+	if msg.SubType == "calls" {
 		notification.PushType = apns.PushTypeVOIP
 	}
 

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -130,6 +130,9 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	notification.Payload = data
 	notification.Topic = me.ApplePushSettings.ApplePushTopic
 	notification.Priority = apns.PriorityHigh
+	if msg.SubType == "call" {
+		notification.PushType = apns.PushTypeVOIP
+	}
 
 	var pushType = msg.Type
 	if msg.IsIDLoaded {


### PR DESCRIPTION
## Why
Special handling is required to send VoIP notifications.
- The `apns-push-type` header must be set to `"voip"`.
- The bundle ID must have `.voip` appended at the end.

ref
https://developer.apple.com/documentation/usernotifications/sending-notification-requests-to-apns

## What
- Set `notification.PushType` to `"voip"`, `SubType` will be received as `"calls"`.
- Updated the sample to indicate that the bundle ID must end with `.voip`.