### PR TITLE
feat: add TTL field for incoming call

### DIFF
--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -181,6 +181,18 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 		mlog.String("type", msg.Type),
 		mlog.String("ack_id", msg.AckID),
 	)
+
+	// FOR DEBUG
+	if msg.SubType == "calls" || msg.SubType == "calls_ended" {
+		me.logger.Debug(
+			"Calls & Calls ended push notification android",
+			mlog.Time("now", time.Now()),
+			mlog.Int("ttl_input_int64_second", int64(fcmMsg.Android.TTL.Seconds())),
+			mlog.Int("ttl_input_int64", int64(*fcmMsg.Android.TTL)),
+			mlog.Any("full_notification", fcmMsg),
+		)
+	}
+
 	err := me.SendNotificationWithRetry(fcmMsg)
 
 	if err != nil {

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -170,6 +170,11 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 		},
 	}
 
+	if msg.SubType == "calls" {
+		d := TTLForCallsSeconds * time.Second
+		fcmMsg.Android.TTL = &d
+	}
+
 	me.logger.Info(
 		"Sending android push notification",
 		mlog.String("device", me.AndroidPushSettings.Type),

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -173,7 +173,7 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 	if msg.SubType == "calls" || msg.SubType == "calls_ended" {
 		d := TTLForCallsSeconds * time.Second
 		fcmMsg.Android.TTL = &d
-		// fcmMsg.Android.CollapseKey = msg.DeviceID
+		fcmMsg.Android.CollapseKey = msg.DeviceID
 	}
 
 	me.logger.Info(

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -173,7 +173,7 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 	if msg.SubType == "calls" || msg.SubType == "calls_ended" {
 		d := TTLForCallsSeconds * time.Second
 		fcmMsg.Android.TTL = &d
-		fcmMsg.Android.CollapseKey = msg.DeviceID
+		fcmMsg.Android.CollapseKey = msg.ChannelID
 	}
 
 	me.logger.Info(

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -182,18 +182,6 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 		mlog.String("type", msg.Type),
 		mlog.String("ack_id", msg.AckID),
 	)
-
-	// FOR DEBUG
-	if msg.SubType == "calls" || msg.SubType == "calls_ended" {
-		me.logger.Debug(
-			"Calls & Calls ended push notification android",
-			mlog.Time("now", time.Now()),
-			mlog.Int("ttl_input_int64_second", int64(fcmMsg.Android.TTL.Seconds())),
-			mlog.Int("ttl_input_int64", int64(*fcmMsg.Android.TTL)),
-			mlog.Any("full_notification", fcmMsg),
-		)
-	}
-
 	err := me.SendNotificationWithRetry(fcmMsg)
 
 	if err != nil {

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -170,7 +170,7 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 		},
 	}
 
-	if msg.SubType == "calls" {
+	if msg.SubType == "calls" || msg.SubType == "calls_ended" {
 		d := TTLForCallsSeconds * time.Second
 		fcmMsg.Android.TTL = &d
 	}

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -171,7 +171,8 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 	}
 
 	if msg.SubType == "calls" || msg.SubType == "calls_ended" {
-		d := TTLForCallsSeconds * time.Second
+		// d := TTLForCallsSeconds * time.Second
+		d := 0 * time.Second
 		fcmMsg.Android.TTL = &d
 	}
 

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -171,10 +171,9 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 	}
 
 	if msg.SubType == "calls" || msg.SubType == "calls_ended" {
-		// d := TTLForCallsSeconds * time.Second
-		d := 0 * time.Second
+		d := TTLForCallsSeconds * time.Second
 		fcmMsg.Android.TTL = &d
-		fcmMsg.Android.CollapseKey = msg.DeviceID
+		// fcmMsg.Android.CollapseKey = msg.DeviceID
 	}
 
 	me.logger.Info(

--- a/server/android_notification_server.go
+++ b/server/android_notification_server.go
@@ -174,6 +174,7 @@ func (me *AndroidNotificationServer) SendNotification(msg *PushNotification) Pus
 		// d := TTLForCallsSeconds * time.Second
 		d := 0 * time.Second
 		fcmMsg.Android.TTL = &d
+		fcmMsg.Android.CollapseKey = msg.DeviceID
 	}
 
 	me.logger.Info(

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -132,7 +132,8 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	notification.Priority = apns.PriorityHigh
 	if (msg.SubType == "calls" || msg.SubType == "calls_ended") && me.ApplePushSettings.Type == "apple_voip" {
 		notification.PushType = apns.PushTypeVOIP
-		notification.Expiration = time.Now().Add(TTLForCallsSeconds * time.Second)
+		// notification.Expiration = time.Now().Add(TTLForCallsSeconds * time.Second)
+		notification.Expiration = time.Now()
 	}
 
 	var pushType = msg.Type

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -130,7 +130,7 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	notification.Payload = data
 	notification.Topic = me.ApplePushSettings.ApplePushTopic
 	notification.Priority = apns.PriorityHigh
-	if msg.SubType == "calls" && me.ApplePushSettings.Type == "apple_voip" {
+	if (msg.SubType == "calls" || msg.SubType == "calls_ended") && me.ApplePushSettings.Type == "apple_voip" {
 		notification.PushType = apns.PushTypeVOIP
 		notification.Expiration = time.Now().Add(TTLForCallsSeconds * time.Second)
 	}

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -132,7 +132,8 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	notification.Priority = apns.PriorityHigh
 	if (msg.SubType == "calls" || msg.SubType == "calls_ended") && me.ApplePushSettings.Type == "apple_voip" {
 		notification.PushType = apns.PushTypeVOIP
-		notification.Expiration = time.Now().Add(TTLForCallsSeconds * time.Second)
+		// notification.Expiration = time.Now().Add(0 * time.Second)
+		notification.Expiration = time.Now()
 	}
 
 	var pushType = msg.Type

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -241,6 +241,20 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 			mlog.String("ack_id", msg.AckID),
 		)
 
+		// FOR DEBUG
+		if msg.SubType == "calls" || msg.SubType == "calls_ended" {
+			duration := time.Until(notification.Expiration)
+			seconds := duration.Seconds()
+
+			me.logger.Debug(
+				"Calls & Calls ended push notification apple",
+				mlog.Time("now", time.Now()),
+				mlog.Time("ttl_input", notification.Expiration),
+				mlog.Float("ttl_input_seconds", seconds),
+				mlog.Any("full_notification", notification),
+			)
+		}
+
 		res, err := me.SendNotificationWithRetry(notification)
 		if err != nil {
 			me.logger.Error(

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -132,6 +132,7 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	notification.Priority = apns.PriorityHigh
 	if msg.SubType == "calls" && me.ApplePushSettings.Type == "apple_voip" {
 		notification.PushType = apns.PushTypeVOIP
+		notification.Expiration = time.Now().Add(TTLForCallsSeconds * time.Second)
 	}
 
 	var pushType = msg.Type

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -132,8 +132,7 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	notification.Priority = apns.PriorityHigh
 	if (msg.SubType == "calls" || msg.SubType == "calls_ended") && me.ApplePushSettings.Type == "apple_voip" {
 		notification.PushType = apns.PushTypeVOIP
-		// notification.Expiration = time.Now().Add(TTLForCallsSeconds * time.Second)
-		notification.Expiration = time.Now()
+		notification.Expiration = time.Now().Add(TTLForCallsSeconds * time.Second)
 	}
 
 	var pushType = msg.Type

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -132,8 +132,8 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	notification.Priority = apns.PriorityHigh
 	if (msg.SubType == "calls" || msg.SubType == "calls_ended") && me.ApplePushSettings.Type == "apple_voip" {
 		notification.PushType = apns.PushTypeVOIP
-		// notification.Expiration = time.Now().Add(0 * time.Second)
-		notification.Expiration = time.Now()
+		notification.Expiration = time.Now().Add(TTLForCallsSeconds * time.Second)
+		// notification.Expiration = time.Now()
 	}
 
 	var pushType = msg.Type

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -241,20 +241,6 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 			mlog.String("ack_id", msg.AckID),
 		)
 
-		// FOR DEBUG
-		if msg.SubType == "calls" || msg.SubType == "calls_ended" {
-			duration := time.Until(notification.Expiration)
-			seconds := duration.Seconds()
-
-			me.logger.Debug(
-				"Calls & Calls ended push notification apple",
-				mlog.Time("now", time.Now()),
-				mlog.Time("ttl_input", notification.Expiration),
-				mlog.Float("ttl_input_seconds", seconds),
-				mlog.Any("full_notification", notification),
-			)
-		}
-
 		res, err := me.SendNotificationWithRetry(notification)
 		if err != nil {
 			me.logger.Error(

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -133,7 +133,6 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	if (msg.SubType == "calls" || msg.SubType == "calls_ended") && me.ApplePushSettings.Type == "apple_voip" {
 		notification.PushType = apns.PushTypeVOIP
 		notification.Expiration = time.Now().Add(TTLForCallsSeconds * time.Second)
-		// notification.Expiration = time.Now()
 	}
 
 	var pushType = msg.Type

--- a/server/apple_notification_server.go
+++ b/server/apple_notification_server.go
@@ -130,8 +130,10 @@ func (me *AppleNotificationServer) SendNotification(msg *PushNotification) PushR
 	notification.Payload = data
 	notification.Topic = me.ApplePushSettings.ApplePushTopic
 	notification.Priority = apns.PriorityHigh
-	if (msg.SubType == "calls" || msg.SubType == "calls_ended") && me.ApplePushSettings.Type == "apple_voip" {
+	if msg.SubType == "calls" && me.ApplePushSettings.Type == "apple_voip" {
 		notification.PushType = apns.PushTypeVOIP
+	}
+	if msg.SubType == "calls" || msg.SubType == "calls_ended" {
 		notification.Expiration = time.Now().Add(TTLForCallsSeconds * time.Second)
 	}
 

--- a/server/push_notification.go
+++ b/server/push_notification.go
@@ -18,6 +18,9 @@ const (
 	PushSoundNone = "none"
 )
 
+// Time-To-Live for incoming call
+const TTLForCallsSeconds = 60
+
 type PushNotificationAck struct {
 	ID       string `json:"id"`
 	Platform string `json:"platform"`

--- a/server/push_notification.go
+++ b/server/push_notification.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Time-To-Live for incoming call
-const TTLForCallsSeconds = 20
+const TTLForCallsSeconds = 60
 
 type PushNotificationAck struct {
 	ID       string `json:"id"`

--- a/server/push_notification.go
+++ b/server/push_notification.go
@@ -19,7 +19,7 @@ const (
 )
 
 // Time-To-Live for incoming call
-const TTLForCallsSeconds = 60
+const TTLForCallsSeconds = 20
 
 type PushNotificationAck struct {
 	ID       string `json:"id"`


### PR DESCRIPTION
## Background
- https://github.com/stmninc/tunag-chat/issues/707
## Feature
- 通知内容が通話関連の時のみ、TTL（Time to live）を６０秒に設定した。
- これにより、APNs・FCMで６０秒経ったら通知配信処理が破棄される。
- PushProxyの変更のみでTTLを追加しており、BEサーバーの変更はしていない。
そのためTTLの秒数を変更したい場合、PushProxy本体を再デプロイする必要がある。


## Verification
 **実機での検証**




--------
**ログ確認**

モバイル側で確認してもらったところTTLを確認できなかったため、Pushproxyのログに出すことで間接的に確認した。
Apple, Android両方とも、少なくともPushproxy側ではTTLを任意の値で設定できている。

**Apple**

<img width="577" height="266" alt="スクリーンショット 2026-01-28 16 33 57" src="https://github.com/user-attachments/assets/3ce1a25c-4dfd-4c51-a057-0b757149dd5a" />
<img width="446" height="124" alt="image" src="https://github.com/user-attachments/assets/d37c5d48-e8e4-4b96-afa6-af66d3dcc76c" />


**Android**

<img width="631" height="194" alt="image" src="https://github.com/user-attachments/assets/400bf479-9174-4403-a4ee-9199cd13ffc8" />
<img width="776" height="198" alt="image" src="https://github.com/user-attachments/assets/6c388ce6-dbe0-4d83-b119-1f9b680ae54c" />
